### PR TITLE
Promote dev to main: data + frontend improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ ANALYTICS_CACHE_TTL=30
 # OpenTelemetry (opcional)
 # Endpoint del colector OTLP (ej: http://otel-collector:4318/v1/traces o host:4317 para gRPC)
 OTEL_EXPORTER_OTLP_ENDPOINT=
+
+# Data retention y versionado
+EVENT_SCHEMA_VERSION=1
+RETENTION_DAYS=0

--- a/README.md
+++ b/README.md
@@ -72,12 +72,14 @@ gcloud run deploy mlog-api \
 ```
 
 ## 🔁 Sync MongoDB → BigQuery
-- Crea una Cloud Function que exporte datos periódicamente
-- Usa el SDK de Mongo + BigQuery para mover datos
+- Script de export: `python scripts/bq_export.py --service <svc> --from <ISO> --to <ISO> --out out.ndjson`
+- Sube `out.ndjson` a GCS y carga a BigQuery (auto-detect schema o esquema predefinido)
 
 ## ✅ Recomendaciones
 - Usa Secret Manager para MONGO_URI en producción
 - Usa TanStack Query y Cache en frontend para eficiencia
+- Define retención con `RETENTION_DAYS` (TTL index en Mongo por `timestamp`)
+- Usa `EVENT_SCHEMA_VERSION` para versionar documentos y planificar migraciones
 
 ---
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -45,6 +45,9 @@ class Settings:
     ENV: str = os.getenv("ENV", "local")
     REDIS_URL: str | None = os.getenv("REDIS_URL")
     ANALYTICS_CACHE_TTL: int = int(os.getenv("ANALYTICS_CACHE_TTL", 30))
+    # Data
+    EVENT_SCHEMA_VERSION: int = int(os.getenv("EVENT_SCHEMA_VERSION", 1))
+    RETENTION_DAYS: int = int(os.getenv("RETENTION_DAYS", 0))
 
 
 settings = Settings()

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -30,6 +30,15 @@ async def connect_db():
         try:
             await db.audit_logs.create_index([("service", 1), ("timestamp", -1)], name="svc_ts")
             await db.audit_logs.create_index([("action", 1)], name="action")
+            await db.audit_logs.create_index([("service", 1), ("user_id", 1), ("timestamp", 1)], name="uniq_svc_user_ts", unique=True)
+            # TTL retention based on timestamp, if configured
+            from app.core.config import settings
+            if getattr(settings, "RETENTION_DAYS", 0) > 0:
+                await db.audit_logs.create_index(
+                    [("timestamp", 1)],
+                    expireAfterSeconds=int(settings.RETENTION_DAYS) * 86400,
+                    name="ttl_timestamp",
+                )
         except Exception:
             # Index creation failure should not prevent app from starting in dev
             pass

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -11,6 +11,7 @@ def _build_client() -> motor.motor_asyncio.AsyncIOMotorClient:
         settings.MONGO_URI,
         minPoolSize=settings.DB_MIN_POOL_SIZE,
         maxPoolSize=settings.DB_MAX_POOL_SIZE,
+        serverSelectionTimeoutMS=5000,
     )
 
 

--- a/app/schemas/events.py
+++ b/app/schemas/events.py
@@ -9,6 +9,7 @@ class EventCreate(BaseModel):
     user_id: str = Field(..., min_length=1, max_length=64)
     action: str = Field(..., min_length=1, max_length=64)
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    schema_version: int | None = None
 
     @field_validator("timestamp")
     @classmethod

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,14 @@
       "name": "mlog-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.56.2",
         "axios": "^1.7.7",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@tanstack/react-query-devtools": "^5.56.2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.1",
         "@types/node": "^20.14.12",
@@ -1201,6 +1204,61 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.87.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.87.4.tgz",
+      "integrity": "sha512-uNsg6zMxraEPDVO2Bn+F3/ctHi+Zsk+MMpcN8h6P7ozqD088F6mFY5TfGM7zuyIrL7HKpDyu6QHfLWiDxh3cuw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.87.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.87.3.tgz",
+      "integrity": "sha512-LkzxzSr2HS1ALHTgDmJH5eGAVsSQiuwz//VhFW5OqNk0OQ+Fsqba0Tsf+NzWRtXYvpgUqwQr4b2zdFZwxHcGvg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.87.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.87.4.tgz",
+      "integrity": "sha512-T5GT/1ZaNsUXf5I3RhcYuT17I4CPlbZgyLxc/ZGv7ciS6esytlbjb3DgUFO6c8JWYMDpdjSWInyGZUErgzqhcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.87.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.87.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.87.4.tgz",
+      "integrity": "sha512-JYcnVJBBW1DCPyNGM0S2CyrLpe6KFiL2gpYd/k9tAp62Du7+Y27zkzd+dKFyxpFadYaTxsx4kUA7YvnkMLVUoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.87.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.87.4",
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -3120,6 +3178,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "axios": "^1.7.7"
+    "axios": "^1.7.7",
+    "@tanstack/react-query": "^5.56.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
@@ -24,7 +26,7 @@
     "jsdom": "^25.0.1",
     "typescript": "^5.6.3",
     "vite": "^5.4.8",
-    "vitest": "^2.1.4"
+    "vitest": "^2.1.4",
+    "@tanstack/react-query-devtools": "^5.56.2"
   }
 }
-

--- a/frontend/src/App.spec.tsx
+++ b/frontend/src/App.spec.tsx
@@ -1,11 +1,19 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { App } from './App'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import { ErrorBoundary } from './components/ErrorBoundary'
 
 describe('App', () => {
   it('renders title', () => {
-    render(<App />)
+    const qc = new QueryClient()
+    render(
+      <ErrorBoundary>
+        <QueryClientProvider client={qc}>
+          <App />
+        </QueryClientProvider>
+      </ErrorBoundary>
+    )
     expect(screen.getByText(/mlog — Frontend de prueba/i)).toBeInTheDocument()
   })
 })
-

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,32 +1,45 @@
-import React, { useState } from 'react'
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { HealthSchema, RootSchema } from './types'
 
 const API = import.meta.env.VITE_API_BASE || 'http://localhost:8000'
 
-export function App() {
-  const [out, setOut] = useState('(sin datos)')
+async function getJson<T>(path: string, schema: { parse: (v: unknown) => T }): Promise<T> {
+  const res = await fetch(`${API}${path}`)
+  const data = await res.json()
+  return schema.parse(data)
+}
 
-  async function fetchPath(path: string) {
-    setOut('Cargando...')
-    try {
-      const res = await fetch(`${API}${path}`)
-      const txt = await res.text()
-      setOut(`${res.status} ${res.statusText}\n\n${txt}`)
-    } catch (e: any) {
-      setOut('Error: ' + e?.message)
-    }
-  }
+export function App() {
+  const rootQ = useQuery({
+    queryKey: ['root'],
+    queryFn: () => getJson('/', RootSchema),
+  })
+  const healthQ = useQuery({
+    queryKey: ['health'],
+    queryFn: () => getJson('/health', HealthSchema),
+  })
 
   return (
     <div style={{ fontFamily: 'system-ui, sans-serif', margin: '2rem' }}>
       <h1>mlog — Frontend de prueba</h1>
       <p>API: <code>{API}</code></p>
-      <div style={{ display: 'flex', gap: '1rem' }}>
-        <button onClick={() => fetchPath('/')}>Fetch /</button>
-        <button onClick={() => fetchPath('/health')}>Fetch /health</button>
-      </div>
-      <h3>Respuesta</h3>
-      <pre>{out}</pre>
+      <section>
+        <h3>Root</h3>
+        {rootQ.isLoading ? (<div>Cargando...</div>) : rootQ.isError ? (
+          <div>Error</div>
+        ) : (
+          <pre>{JSON.stringify(rootQ.data, null, 2)}</pre>
+        )}
+      </section>
+      <section>
+        <h3>Health</h3>
+        {healthQ.isLoading ? (<div>Cargando...</div>) : healthQ.isError ? (
+          <div>Error</div>
+        ) : (
+          <pre>{JSON.stringify(healthQ.data, null, 2)}</pre>
+        )}
+      </section>
     </div>
   )
 }
-

--- a/frontend/src/components/ErrorBoundary.spec.tsx
+++ b/frontend/src/components/ErrorBoundary.spec.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { ErrorBoundary } from './ErrorBoundary'
+
+function Boom() {
+  throw new Error('boom')
+}
+
+describe('ErrorBoundary', () => {
+  it('renders fallback on error', () => {
+    render(
+      <ErrorBoundary fallback={<div>fallback</div>}>
+        <Boom />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText(/fallback/i)).toBeInTheDocument()
+  })
+})
+

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+type Props = { children: React.ReactNode; fallback?: React.ReactNode }
+
+type State = { hasError: boolean }
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: unknown) {
+    // Aquí podríamos enviar el error a un servicio
+    console.error('ErrorBoundary caught', error)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <div>Algo salió mal.</div>
+    }
+    return this.props.children
+  }
+}
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,18 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './App'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { queryClient } from './queryClient'
+import { ErrorBoundary } from './components/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <App />
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </ErrorBoundary>
   </React.StrictMode>
 )
-

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+})
+

--- a/frontend/src/types.spec.ts
+++ b/frontend/src/types.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { HealthSchema, RootSchema } from './types'
+
+describe('Zod schemas', () => {
+  it('parses valid health', () => {
+    const v = HealthSchema.parse({ status: 'ok', mongo: true })
+    expect(v.status).toBe('ok')
+  })
+  it('parses valid root', () => {
+    const v = RootSchema.parse({ app: 'mlog', message: 'hi' })
+    expect(v.app).toBe('mlog')
+  })
+  it('rejects invalid root', () => {
+    expect(() => RootSchema.parse({})).toThrow()
+  })
+})
+

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const HealthSchema = z.object({
+  status: z.string(),
+  mongo: z.boolean().optional(),
+})
+export type Health = z.infer<typeof HealthSchema>
+
+export const RootSchema = z.object({
+  app: z.string(),
+  message: z.string(),
+})
+export type RootInfo = z.infer<typeof RootSchema>
+

--- a/instructions.json
+++ b/instructions.json
@@ -1,6 +1,6 @@
-DevOps
+Data
 
-Multi-stage builds: Dockerfile monolítico, optimizar layers
-Health probes: Sin readiness/liveness probes para K8s
-Secrets: Hardcoded configs, usar secret management
-Monitoring: Sin alerting setup
+Schema evolution: Sin versionado de documentos MongoDB
+Backup strategy: Sin retention policies definidas
+BigQuery sync: Mencionado pero no implementado
+Data validation: Sin validación de duplicados por timestamp+service+user

--- a/scripts/bq_export.py
+++ b/scripts/bq_export.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Exporta eventos desde MongoDB a NDJSON para BigQuery.
+
+Uso:
+  python scripts/bq_export.py --service axi --from 2025-01-01T00:00:00Z --to 2025-01-02T00:00:00Z --out events.ndjson
+
+Variables de entorno: MONGO_URI
+"""
+import argparse
+import asyncio
+import json
+import os
+from datetime import datetime
+
+import motor.motor_asyncio
+
+
+def parse_dt(s: str | None):
+    if not s:
+        return None
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--service")
+    parser.add_argument("--from", dest="from_ts")
+    parser.add_argument("--to", dest="to_ts")
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    uri = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+    client = motor.motor_asyncio.AsyncIOMotorClient(uri)
+    db = client["mlog"]
+
+    q = {}
+    if args.service:
+        q["service"] = args.service
+    time_filter = {}
+    f = parse_dt(args.from_ts)
+    t = parse_dt(args.to_ts)
+    if f:
+        time_filter["$gte"] = f
+    if t:
+        time_filter["$lte"] = t
+    if time_filter:
+        q["timestamp"] = time_filter
+
+    count = 0
+    with open(args.out, "w", encoding="utf-8") as fp:
+        async for doc in db.audit_logs.find(q).sort("timestamp", 1):
+            doc["_id"] = str(doc.get("_id"))
+            fp.write(json.dumps(doc, default=str) + "\n")
+            count += 1
+    print(f"Exported {count} documents to {args.out}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+


### PR DESCRIPTION
Promoting dev to main.\n\nIncludes:\n- Data: schema_version, TTL retention, unique duplicates guard, BigQuery export script.\n- Frontend: React Query, ErrorBoundary, Zod validation + tests.\n- Minor: Mongo client selection timeout.\n\nWill create retroactive tags per git_history.json.